### PR TITLE
Changed Search generation mechanism and added a new SearchGenerator interface

### DIFF
--- a/automsr/config.py
+++ b/automsr/config.py
@@ -1,4 +1,5 @@
 import json
+from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
@@ -12,6 +13,11 @@ from email_validator import (
 from email_validator import validate_email as _validate_email
 from pydantic import AfterValidator, BaseModel, ConfigDict, Field, SecretStr
 from typing_extensions import Annotated
+
+
+class SearchType(Enum):
+    RANDOM = "random"
+    LOREM = "lorem"
 
 
 def validate_version(value: str) -> str:
@@ -73,10 +79,22 @@ class Profile(BaseModel):
 class AutomsrConfig(BaseModel):
     """
     >>> profiles = [{"email": "1@gmail.com", "profile": "p1"}, {"email": "2@gmail.com", "profile": "p2"}]
-    >>> _ = AutomsrConfig(profiles=profiles)
+    >>> config = AutomsrConfig(profiles=profiles)
+    >>> assert config.search_type is SearchType.RANDOM
+
+    >>> config = AutomsrConfig(**{"profiles": profiles, "search_type": "lorem"})
+    >>> assert config.search_type is SearchType.LOREM
+
+    >>> AutomsrConfig(**{"profiles": profiles, "search_type": "foo"})  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+        ...
+    pydantic_core._pydantic_core.ValidationError: 1 validation error for AutomsrConfig
+    search_type
+      Input should be 'random' or 'lorem' [type=enum, input_value='foo', input_type=str]
     """
 
     profiles: List[Profile] = Field(..., min_length=1)
+    search_type: SearchType = Field(default=SearchType.RANDOM)
 
     rewards_homepage: ValidatedURL = Defaults.rewards_homepage
     bing_homepage: ValidatedURL = Defaults.bing_homepage

--- a/automsr/search.py
+++ b/automsr/search.py
@@ -1,50 +1,87 @@
+import locale
 import logging
 import random
 import string
-from abc import ABC
-from typing import Generator
-from urllib.parse import urlparse
+import sys
+import warnings
+from abc import ABC, abstractmethod
+from typing import Generator, Optional, Set
 
+from attr import define, field
+from faker import Faker  # type: ignore
+from faker.config import AVAILABLE_LOCALES as _AVAILABLE_LOCALES_IN_FAKER  # type: ignore
 from selenium.webdriver.common.keys import Keys
 
 logger = logging.getLogger(__name__)
 
 
-def is_valid_url(url: str) -> bool:
-    try:
-        result = urlparse(url)
-    except (AttributeError, ValueError):
-        return False
+def _get_locale() -> str:
+    """
+    Workaround for `locale.getlocale()` method on Windows.
+
+    See issues https://github.com/python/cpython/issues/82986 and
+    https://github.com/pytest-dev/pytest-nunit/issues/67 to get a grasp on it.
+
+    TL;DR: the preferred / non-deprecated-since-Py3.11 method to retrieve the current locale
+    should be `locale.getlocale()`; however, on windows, the correct locale is the one
+    returned from `locale.getdefaultlocale()`.
+    """
+
+    default_language_code = "en-US"
+
+    if sys.platform not in ("win32", "cygwin"):
+        language_code = locale.getlocale()[0]
+        if language_code and language_code in _AVAILABLE_LOCALES_IN_FAKER:
+            return language_code
+        else:
+            return default_language_code
+
+    # if we are here, we need to use the workaround for Win platforms
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=DeprecationWarning)
+        language_code = locale.getdefaultlocale()[0]
+
+    if language_code and language_code in _AVAILABLE_LOCALES_IN_FAKER:
+        return language_code
     else:
-        return all(field for field in (result.scheme, result.netloc, result.path))
+        return default_language_code
 
 
+def _get_faker_locales() -> Set[str]:
+    return {_get_locale(), "en-US"}
+
+
+@define(slots=False)
 class SearchGenerator(ABC):
     """
     Interface for search generators to be used as generators of
     query for Bing searches
     """
 
-    def query_gen(self) -> Generator[str, None, None]:
+    @abstractmethod
+    def sleep_time(self) -> Generator[float, None, None]:
         """
-        Returns a generator of queries to be used with Bing searches
-        """
-
-        raise NotImplementedError
-
-    def sleep_time(self) -> float:
-        """
-        Returns the time to sleep in seconds between Bing searches
+        Returns a generator of times to wait in seconds between Bing searches,
         """
 
         raise NotImplementedError
 
+    @abstractmethod
+    def query(self) -> Generator[str, None, None]:
+        """
+        Returns a generator of queries to be used with Bing searches.
+        """
 
+        raise NotImplementedError
+
+
+@define
 class RandomSearchGenerator(SearchGenerator):
-    def sleep_time(self):
-        return 1.5
+    def sleep_time(self) -> Generator[float, None, None]:
+        while True:
+            yield 1.5
 
-    def query_gen(self):
+    def query(self) -> Generator[str, None, None]:
         alphabet = string.ascii_lowercase
         length = 70
         word = "".join(random.choices(alphabet, k=length))
@@ -58,3 +95,32 @@ class RandomSearchGenerator(SearchGenerator):
         while True:
             logger.debug("Yielding backspace...")
             yield Keys.BACKSPACE
+
+
+@define
+class FakerSearchGenerator(SearchGenerator):
+    """
+    Search Generator that uses Faker as backend for
+    determining the times and the queries to use
+    for Bing searches.
+    """
+
+    seed: Optional[int] = None
+    _faker: Faker = field(factory=lambda: Faker(locale=list(_get_faker_locales())))
+
+    def __attrs_post_init__(self) -> None:
+        if self.seed is not None:
+            self._faker.seed_instance(seed=self.seed)
+
+    def sleep_time(self) -> Generator[float, None, None]:
+        while True:
+            retval: float = self._faker.pyfloat(positive=True, min_value=2, max_value=5)
+            yield retval
+
+    def query(self) -> Generator[str, None, None]:
+        while True:
+            sentence: str = self._faker.sentence(nb_words=6, variable_nb_words=True)
+
+            # add manually backspaces for previous query searches
+            retval = f"{Keys.BACKSPACE * 50}{sentence}"
+            yield retval

--- a/tests/configs/config.example.yaml
+++ b/tests/configs/config.example.yaml
@@ -6,6 +6,13 @@ version: v1
 
 # Required.
 automsr:
+  # Optional.
+  # Type of search generator used with Bing searches.
+  # Can be:
+  # - random (DEFAULT): a string of random characters will be used.
+  # - lorem: a lorem-ipsum-like sentence will be used.
+  search_type: random
+
   # Required.
   # List of profiles to provide to the tool.
   # A profile represent a Chrome profile already logged in https://rewards.bing.com


### PR DESCRIPTION
Closes #58 .

A new option is added to the `config.yaml`: `automsr/search_type` of value string enum.
The valid options are `random` (default if the attribute is missing) or `lorem`, the option that enables the new search generator as described below.

A new search generator was added, `FakerSearchGenerator`. As the name implies, it uses the library `Faker` to both generate a random time to sleep, and a valid sentence to search of 6 words (more or less; see `variable_nb_words=True`).

Also, now the characters are not sent to the input text field at once, but they are sent one by one with `selenium.ActionChains`. This is still compatible with the old `RandomSearchGenerator`, since also a backspace is a valid key to send to a text field.

Another change is the time to sleep; it is now a generator too, so its value can be changed based on some requirements.